### PR TITLE
エラーメッセージエリアをborder-boxに変更

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -98,6 +98,7 @@ button{
 .alert{
 	width: 100%;
 	padding: 6px;
+	box-sizing: border-box;
 }
 
 .alert-list{


### PR DESCRIPTION
概要
エラーメッセージエリアが枠からはみ出していたためborder-boxに変更した